### PR TITLE
Require usage of elseif instead of else if

### DIFF
--- a/CodeIgniter4/ruleset.xml
+++ b/CodeIgniter4/ruleset.xml
@@ -242,6 +242,11 @@
     Checks there are no blank lines before a function closing brace.
     -->
     <rule ref="CodeIgniter4.WhiteSpace.FunctionClosingBraceSpace"/>
+    <!-- 
+    The keyword elseif SHOULD be used instead of else if so that all control
+    keywords look like single words.
+    -->
+    <rule ref="PSR2.ControlStructures.ElseIfDeclaration"/>
     <!--
     Checks for each declarations are styled properly.
     -->


### PR DESCRIPTION
This PR adds a requirement to use `elseif` control keywords instead of `else if`.

Ref: https://github.com/codeigniter4/CodeIgniter4/pull/3495#issuecomment-674542839